### PR TITLE
[Fix] Update FontAwesome version

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "private": true,
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^6.2.0",
+    "@fortawesome/fontawesome-free": "^6.2.1",
     "npm-run-all": "^4.1.5"
   }
 }

--- a/templates/link.hbs
+++ b/templates/link.hbs
@@ -5,7 +5,7 @@
 
   {{#unless label}}
     {{#if iconType}}
-      <i class="fa fa-{{iconType}} link__icon"></i>
+      <i class="fa-brands fa-{{iconType}} link__icon"></i>
     {{/if}}
   {{/unless}}
 </a>

--- a/templates/page.hbs
+++ b/templates/page.hbs
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{title}}</title>
     <link href="favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.1/css/all.min.css" integrity="sha512-MV7K8+y+gLIBoVD59lQIYicR65iaqukzvf/nwasF0nqhPay5w/9lJmVM2hMDcnK1OnMGCdVK+iQrJ7lzPJQd1w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 
     {{!-- Red Hat Display font --}}
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/templates/whatsAppButton.hbs
+++ b/templates/whatsAppButton.hbs
@@ -1,6 +1,5 @@
 <div class="whatsapp-btn">
   <a class="whatsapp-btn__green-background" href="{{link}}" target="_blank" aria-label="{{ariaLabel}}" title="Manao Whatsapp">
-   <i class="fa fa-whatsapp whatsapp-btn__logo"></i>
+   <i class="fab fa-whatsapp whatsapp-btn__logo"></i>
   </a>
 </div>
-


### PR DESCRIPTION
Update version of Font Awesome 4.7.0 to 6.2.1.

The old version 4.7.0 was causing problems because it was already obsolete.
Modify the syntaxes on severals files according to the new version.
Change the "**facebook**" option to "**facebook-f**" in the "**Link**" component so that it shows the "**f**" alone and not with the circle